### PR TITLE
Themes: Get default theme from CMSettings

### DIFF
--- a/services/core/java/com/android/server/ThemeService.java
+++ b/services/core/java/com/android/server/ThemeService.java
@@ -1188,7 +1188,7 @@ public class ThemeService extends IThemeService.Stub {
     };
 
     private void processInstalledThemes() {
-        final String defaultTheme = ThemeUtils.getDefaultThemePackageName(mContext);
+        final String defaultTheme = getDefaultThemePackageName(mContext);
         Message msg;
         // Make sure the default theme is the first to get processed!
         if (!ThemeConfig.SYSTEM_DEFAULT.equals(defaultTheme)) {
@@ -1246,5 +1246,32 @@ public class ThemeService extends IThemeService.Stub {
         }
 
         return null;
+    }
+
+    /**
+     * Get the default theme package name
+     * Historically this was done using {@link ThemeUtils#getDefaultThemePackageName(Context)} but
+     * the setting that is queried in that method uses the AOSP settings provider but the setting
+     * is now in CMSettings.  Since {@link ThemeUtils} is in the core framework we cannot access
+     * CMSettings.
+     * @param context
+     * @return Default theme package name
+     */
+    private static String getDefaultThemePackageName(Context context) {
+        final String defaultThemePkg = CMSettings.Secure.getString(context.getContentResolver(),
+                CMSettings.Secure.DEFAULT_THEME_PACKAGE);
+        if (!TextUtils.isEmpty(defaultThemePkg)) {
+            PackageManager pm = context.getPackageManager();
+            try {
+                if (pm.getPackageInfo(defaultThemePkg, 0) != null) {
+                    return defaultThemePkg;
+                }
+            } catch (PackageManager.NameNotFoundException e) {
+                // doesn't exist so system will be default
+                Log.w(TAG, "Default theme " + defaultThemePkg + " not found", e);
+            }
+        }
+
+        return SYSTEM_DEFAULT;
     }
 }


### PR DESCRIPTION
Get default theme from CMSettings when processing themes in the
ThemeService

CYNGNOS-1912
Change-Id: I9de907e514ba857d175026e4d79f946fa479db40