### PR TITLE
Keyguard: Show backdrop when sim pin secure screen shown

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
@@ -2149,7 +2149,9 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
             backdropBitmap = mKeyguardWallpaper;
         }
 
-        boolean keyguardVisible = (mState != StatusBarState.SHADE);
+        // HACK: Consider keyguard as visible if showing sim pin security screen
+        KeyguardUpdateMonitor updateMonitor = KeyguardUpdateMonitor.getInstance(mContext);
+        boolean keyguardVisible = mState != StatusBarState.SHADE || updateMonitor.isSimPinSecure();
 
         if (!mKeyguardFadingAway && keyguardVisible && backdropBitmap != null && mScreenOn) {
             // if there's album art, ensure visualizer is visible


### PR DESCRIPTION
Devices that support bluring remove FLAG_SHOW_WALLPAPER from the
layout params flags which causes the foreground activity to be
completely visible when the sim pin security screen is shown.  If
this screen is visible we treat it as if the keyguard is visible and
show the backdrop if available, otherwise it is blurred.

Change-Id: Ifeae28816cc2f1fad30a2edf1cf51d5cabb005e9
TICKET: CYNGNOS-1266